### PR TITLE
Fix build issues and parallelize build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ ARG FMTLIB_VER=10.1.1
 ARG GLSLANG_VER=sdk-1.3.261.1
 ARG MINIZ_VER=3.0.2
 
+# Use labels to make images easier to organize
+LABEL libnx32.version="${LIBNX32_HASH}"
+LABEL buildscripts.version="${BUILDSCRIPTS_HASH}"
+
 # Prepare devkitpro env
 ENV DEVKITPRO=/opt/devkitpro
 ENV DEVKITARM=/opt/devkitpro/devkitARM
@@ -252,10 +256,6 @@ COPY --from=fmt --chown=vita2hos:vita2hos $DEVKITPRO $DEVKITPRO
 COPY --from=uam-host --chown=vita2hos:vita2hos $DEVKITPRO $DEVKITPRO
 COPY --from=uam-switch --chown=vita2hos:vita2hos $DEVKITPRO $DEVKITPRO
 COPY --from=miniz --chown=vita2hos:vita2hos $DEVKITPRO $DEVKITPRO
-
-# Use labels to make images easier to organize
-LABEL libnx32.version="${LIBNX32_HASH}"
-LABEL buildscripts.version="${BUILDSCRIPTS_HASH}"
 
 USER vita2hos
 WORKDIR /home/vita2hos

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,7 @@ FROM portlibs-prepare AS spirv
 RUN cd SPIRV-Cross \
     && mkdir build && cd build \
     && cmake .. \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/devkitARM.cmake \
     -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${DEVKITPRO}/cmake/Platform/NintendoSwitch.cmake \
     -DCMAKE_EXE_LINKER_FLAGS="-specs=${NX_ROOT}/switch32.specs" \
@@ -220,6 +221,7 @@ FROM uam-switch AS miniz
 RUN cd miniz \
     && mkdir build && cd build \
     && cmake .. \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/devkitARM.cmake \
     -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${DEVKITPRO}/cmake/Platform/NintendoSwitch.cmake \
     -DCMAKE_EXE_LINKER_FLAGS="-specs=${NX_ROOT}/switch32.specs" \


### PR DESCRIPTION
This PR fixes a few issues that were encountered while building locally and in CI.
The build process was parallelized again, so all the tools/libs that don't depend on others are built independently.

The first commit partially reverts #71, since DKP blocks GitHub Actions and I'm guessing some IPs just weren't blocked before, which allowed these changes to work for a some time.
But since the workflows for #74 are failing again, we can assume most of the remaining IPs have been blocked as well.

Some CMake projects refused to build because the CMake version in the image is not backwards compatible with version 3.0 anymore. Forcing to build them anyway works fine, so that's what I opted for.

The ARGS and LABELS have been moved to the top again.
Changes to LABELS don't cause any cache misses and changes to ARGS only cause them on usage, so the cache will only be invalidated from the "checkout" commands onwards.

Note that if there was a cache miss in an earlier image (like buildscripts or libnx) then all the images based on it will also be rebuilt, but that has also been the case before.